### PR TITLE
Update node16 to 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'git-changesets'
 description: 'Github Action to determine changed files (aka changesets)'
 author: 'Collin Miller'
 runs:
-    using: node16
+    using: node20
     main: dist/index.js
 inputs:
     token:


### PR DESCRIPTION
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: collin-miller/git-changesets@master. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.